### PR TITLE
fix: 导出反馈组件

### DIFF
--- a/packages/editor/src/packages/index.tsx
+++ b/packages/editor/src/packages/index.tsx
@@ -6,5 +6,6 @@ export * from './Layout';
 export * from './EChart';
 export * from './Functional';
 export * from './Basic';
+export * from './FeedBack';
 export { IFrame, IFrameConfig } from './IFrame';
 import './index.less';


### PR DESCRIPTION
**目的**

解决编辑器页面报错，Feedback组件无法加入画板

**变更内容**

**解决的问题**
packages/editor/src/packages/FeedBack目录没有在packages/editor/src/packages/index.tsx中导出，在编辑器页面报错如下：
Uncaught TypeError: Cannot read properties of undefined (reading 'props')

**测试**

**开发流程**

**注意事项**
