### PR TITLE
feat: marsTable组件 actions按钮隐藏时去掉占位元素

### DIFF
--- a/packages/editor/src/packages/Scene/MarsTable/MarsTable.tsx
+++ b/packages/editor/src/packages/Scene/MarsTable/MarsTable.tsx
@@ -349,6 +349,7 @@ const MarsTable = ({ id, type, config, elements, onCheckedChange }: ComponentTyp
                       btnTxt = '解析异常';
                     }
                   }
+                  if (btnTxt === '') return;
                   return (
                     <Button key={btn.eventName} type="link" size="small" danger={btn.danger} onClick={() => handleActionClick(btn.eventName, record)}>
                       {btnTxt}


### PR DESCRIPTION
---
name: pull request
about: marsTable组件 actions按钮隐藏时去掉占位元素
title: marsTable组件 actions按钮隐藏时去掉占位元素
labels: pr
assignees: ''
---

**目的**

解决按钮文本为空时，出现的占位元素问题

**变更内容**
packages\editor\src\packages\Scene\MarsTable\MarsTable.tsx

- [ ] 修改 1：按钮文本为空时，不渲染元素内容
