### PR TITLE
fix: link、img、text组件click事件参数名对不上schema配置的eventName  feat: table组件支持折叠按钮，列弹窗标题增加key

### DIFF
--- a/packages/editor/src/packages/Basic/Image/Schema.ts
+++ b/packages/editor/src/packages/Basic/Image/Schema.ts
@@ -1,3 +1,12 @@
+/*
+ * @Author: zq
+ * @Description: 文件说明
+ * @LastEditors: zq
+ * @Company: 沃尔玛
+ * @Date: 2024-12-05 09:19:37
+ * @LastEditTime: 2024-12-05 09:49:38
+ * @FilePath: /lowcode-web/packages/editor/src/packages/Basic/Image/Schema.ts
+ */
 /**
  * 组件配置和属性值
  */
@@ -46,7 +55,7 @@ export default {
   // 组件事件
   events: [
     {
-      value: 'handleClick',
+      value: 'onClick',
       name: '点击事件',
     },
   ],

--- a/packages/editor/src/packages/Basic/Image/Schema.ts
+++ b/packages/editor/src/packages/Basic/Image/Schema.ts
@@ -1,12 +1,3 @@
-/*
- * @Author: zq
- * @Description: 文件说明
- * @LastEditors: zq
- * @Company: 沃尔玛
- * @Date: 2024-12-05 09:19:37
- * @LastEditTime: 2024-12-05 09:49:38
- * @FilePath: /lowcode-web/packages/editor/src/packages/Basic/Image/Schema.ts
- */
 /**
  * 组件配置和属性值
  */

--- a/packages/editor/src/packages/Basic/Link/Schema.ts
+++ b/packages/editor/src/packages/Basic/Link/Schema.ts
@@ -1,3 +1,12 @@
+/*
+ * @Author: zq
+ * @Description: 文件说明
+ * @LastEditors: zq
+ * @Company: 沃尔玛
+ * @Date: 2024-12-05 09:38:21
+ * @LastEditTime: 2024-12-05 09:49:20
+ * @FilePath: /lowcode-web/packages/editor/src/packages/Basic/Link/Schema.ts
+ */
 /**
  * 组件配置和属性值
  */
@@ -49,7 +58,7 @@ export default {
   // 组件事件
   events: [
     {
-      value: 'handleClick',
+      value: 'onClick',
       name: '点击事件',
     },
   ],

--- a/packages/editor/src/packages/Basic/Link/Schema.ts
+++ b/packages/editor/src/packages/Basic/Link/Schema.ts
@@ -1,12 +1,3 @@
-/*
- * @Author: zq
- * @Description: 文件说明
- * @LastEditors: zq
- * @Company: 沃尔玛
- * @Date: 2024-12-05 09:38:21
- * @LastEditTime: 2024-12-05 09:49:20
- * @FilePath: /lowcode-web/packages/editor/src/packages/Basic/Link/Schema.ts
- */
 /**
  * 组件配置和属性值
  */

--- a/packages/editor/src/packages/Basic/Text/Schema.tsx
+++ b/packages/editor/src/packages/Basic/Text/Schema.tsx
@@ -122,7 +122,7 @@ export default {
   // 组件事件
   events: [
     {
-      value: 'handleClick',
+      value: 'onClick',
       name: '点击事件',
     },
   ],

--- a/packages/editor/src/packages/Basic/Title/Schema.ts
+++ b/packages/editor/src/packages/Basic/Title/Schema.ts
@@ -101,7 +101,7 @@ export default {
   // 组件事件
   events: [
     {
-      value: 'handleClick',
+      value: 'onClick',
       name: '点击事件',
     },
   ],

--- a/packages/editor/src/packages/Scene/MarsTable/ColumnSetting.tsx
+++ b/packages/editor/src/packages/Scene/MarsTable/ColumnSetting.tsx
@@ -141,8 +141,10 @@ const ColumnSetting = memo((props: IModalProp) => {
   const handleCancel = () => {
     setVisible(false);
   };
+  const values = form.getFieldsValue();
+  const title = `列设置(${values?.dataIndex})`
   return (
-    <Modal title="列设置" open={visible} onOk={handleOk} onCancel={handleCancel} width={900}>
+    <Modal title={title} open={visible} onOk={handleOk} onCancel={handleCancel} width={900}>
       <Form form={form} labelCol={{ span: 6 }}>
         <Tabs items={items} />
       </Form>
@@ -271,6 +273,37 @@ const DisplaySetting = () => {
       </Form.Item>
       <Form.Item label="可复制" name="copyable" tooltip="开启后，列增加复制功能，只对文本生效" {...layout}>
         <Switch />
+      </Form.Item>
+      <Form.Item shouldUpdate noStyle>
+        {(form: FormInstance) => {
+          const type = form.getFieldValue('type');
+          if (type === 'image')
+            return (
+                <Form.Item name="imageConfig">
+                  <Form.Item label="宽度" name={['imageConfig', 'width']} {...layout}>
+                    <Input placeholder='string | number' />
+                  </Form.Item>
+                  <Form.Item label="高度" name={['imageConfig', 'height']} {...layout}>
+                    <Input placeholder='string | number' />
+                  </Form.Item>
+                </Form.Item>
+            );
+        }}
+      </Form.Item>
+      <Form.Item shouldUpdate>
+        {(form: FormInstance) => {
+          const type = form.getFieldValue('type'); // 假设你在某个地方已经定义了'type'字段
+          if (type === 'action') {
+            return (
+              <Form.Item label="折叠按钮" name="moreActionIndex" {...layout} tooltip="指定从第n个按钮开始折叠">
+                  <InputNumber min={0} max={999} style={{
+                    width: '60px',
+                  }} />
+              </Form.Item>
+            );
+          }
+          return null;
+        }}
       </Form.Item>
       <Form.Item shouldUpdate noStyle>
         {(form: FormInstance) => {

--- a/packages/editor/src/packages/Scene/MarsTable/MarsTable.tsx
+++ b/packages/editor/src/packages/Scene/MarsTable/MarsTable.tsx
@@ -367,6 +367,7 @@ const MarsTable = ({ id, type, config, elements, onCheckedChange }: ComponentTyp
                   </Button>
                 );
               });
+              // 配置了折叠功能，且存在需要折叠的按钮
               if (moreActionIndex && btns.slice(moreActionIndex - 1).length) {
                 const content = <div style={{
                   display: 'flex',

--- a/packages/editor/src/packages/Scene/MarsTable/MarsTable.tsx
+++ b/packages/editor/src/packages/Scene/MarsTable/MarsTable.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
-import { Button, Table, Image, Tag, TablePaginationConfig, Tooltip, Typography, Badge } from 'antd';
+import { Button, Table, Image, Tag, TablePaginationConfig, Tooltip, Typography, Badge, Popover } from 'antd';
 import { useDrop } from 'react-dnd';
 import { pickBy } from 'lodash-es';
 import * as icons from '@ant-design/icons';
@@ -12,6 +12,8 @@ import { usePageStore } from '@/stores/pageStore';
 import { ComponentType, IDragTargetItem } from '@/packages/types';
 import { get } from 'lodash-es';
 import styles from './index.module.less';
+import { isNumber } from 'lodash-es';
+import { EllipsisOutlined } from '@ant-design/icons';
 
 export interface IConfig {
   bordered: boolean;
@@ -303,14 +305,16 @@ const MarsTable = ({ id, type, config, elements, onCheckedChange }: ComponentTyp
               return <Badge status="success" text={txt.toString()} />;
             }
             if (item.type === 'image') {
+              const { width, height } = item?.imageConfig || {};
               if (Array.isArray(txt)) {
                 return (
                   <Image.PreviewGroup items={txt}>
-                    <Image width={30} src={txt[0]} />
+                    <Image width={width} height={height} src={txt[0]} />
                   </Image.PreviewGroup>
                 );
               }
-              return (txt?.startsWith('http') && <Image src={txt} width={30} />) || txt;
+              const adaptVal = (val: string) => isNumber(Number(val)) ? Number(val) : val;
+              return (txt?.startsWith?.('http') && <Image src={txt} width={adaptVal(width)} height={adaptVal(height)} />) || txt;
             }
             if (item.type === 'tag') {
               if (Array.isArray(txt)) {
@@ -333,39 +337,61 @@ const MarsTable = ({ id, type, config, elements, onCheckedChange }: ComponentTyp
               }
               return txt?.toString();
             }
-            if (item.type === 'action')
+            if (item.type === 'action'){
+              const { moreActionIndex } = item;
+              const btns = item.list?.map((btn: any) => {
+                let btnTxt = '';
+                if (typeof btn.text === 'string') {
+                  btnTxt = btn.text;
+                } else if (btn.text?.type === 'static') {
+                  btnTxt = btn.text.value;
+                } else {
+                  try {
+                    const renderFn = new Function('text', 'record', 'index', `return (${btn.text.value})(text,record,index);`);
+                    btnTxt = renderFn('', record, index);
+                  } catch (error) {
+                    console.error(`列[${btn.title}]渲染失败`, error);
+                    btnTxt = '解析异常';
+                  }
+                }
+                if (btnTxt === '') return;
+                return (
+                  <Button
+                    key={btn.eventName}
+                    type="link"
+                    size="small"
+                    danger={btn.danger}
+                    onClick={() => handleActionClick(btn.eventName, record)}
+                  >
+                    {btnTxt}
+                  </Button>
+                );
+              });
+              if (moreActionIndex && btns.slice(moreActionIndex - 1).length) {
+                const content = <div style={{
+                  display: 'flex',
+                  flexDirection: 'column'
+                }}>
+                  {btns.slice(moreActionIndex - 1)}
+                </div>
+                return (
+                  <div className={styles.action}>
+                    { btns.slice(0, moreActionIndex - 1)}
+                     <Popover
+                      trigger="click"
+                      content={ content }
+                    >
+                      <EllipsisOutlined />
+                    </Popover>
+                  </div>
+                );
+              }
               return (
                 <div className={styles.action}>
-                  {item.list?.map((btn: any) => {
-                    let btnTxt = '';
-                    if (typeof btn.text === 'string') {
-                      btnTxt = btn.text;
-                    } else if (btn.text?.type === 'static') {
-                      btnTxt = btn.text.value;
-                    } else {
-                      try {
-                        const renderFn = new Function('text', 'record', 'index', `return (${btn.text.value})(text,record,index);`);
-                        btnTxt = renderFn('', record, index);
-                      } catch (error) {
-                        console.error(`列[${btn.title}]渲染失败`, error);
-                        btnTxt = '解析异常';
-                      }
-                    }
-                    if (btnTxt === '') return;
-                    return (
-                      <Button
-                        key={btn.eventName}
-                        type="link"
-                        size="small"
-                        danger={btn.danger}
-                        onClick={() => handleActionClick(btn.eventName, record)}
-                      >
-                        {btnTxt}
-                      </Button>
-                    );
-                  })}
+                  {btns}
                 </div>
               );
+            }
             return txt;
           },
         };

--- a/packages/materials/Basic/Text/Text.tsx
+++ b/packages/materials/Basic/Text/Text.tsx
@@ -1,3 +1,12 @@
+/*
+ * @Author: zq
+ * @Description: 文件说明
+ * @LastEditors: zq
+ * @Company: 沃尔玛
+ * @Date: 2024-11-04 16:02:24
+ * @LastEditTime: 2024-11-04 16:21:09
+ * @FilePath: /lowcode-web/packages/materials/Basic/Text/Text.tsx
+ */
 import { useState, useEffect, useImperativeHandle, forwardRef } from 'react';
 import { Typography } from 'antd';
 import dayjs from 'dayjs';

--- a/packages/materials/Basic/Text/Text.tsx
+++ b/packages/materials/Basic/Text/Text.tsx
@@ -3,8 +3,8 @@
  * @Description: 文件说明
  * @LastEditors: zq
  * @Company: 沃尔玛
- * @Date: 2024-11-04 16:02:24
- * @LastEditTime: 2024-11-04 16:21:09
+ * @Date: 2024-12-05 12:43:19
+ * @LastEditTime: 2024-12-05 12:44:05
  * @FilePath: /lowcode-web/packages/materials/Basic/Text/Text.tsx
  */
 import { useState, useEffect, useImperativeHandle, forwardRef } from 'react';

--- a/packages/materials/Functional/Button/AuthButton.tsx
+++ b/packages/materials/Functional/Button/AuthButton.tsx
@@ -3,6 +3,9 @@ import storage from '@materials/utils/storage';
 import { useParams } from 'react-router-dom';
 import { renderFormula } from '@materials/utils/util';
 
+const renderBtn = (props: any) => (<Button {...props} onClick={props.onClick}>
+  {props.children}
+</Button>);
 /**
  * 按钮权限控制
  */
@@ -17,22 +20,41 @@ export default function AuthButton({ authCode, authScript, ...props }: any) {
    * 3. 如果是项目打开，则判断是否配置了权限，根据权限进行查找，命中则显示按钮，否则不显示
    */
   if (!authCode || (id && !window.microApp) || (projectId && authCode && buttons.find((b: any) => b.code === newAuthCode))) {
-    return (
-      <Button {...props} onClick={props.onClick}>
-        {props.children}
-      </Button>
-    );
+    return renderBtn(props);
   }
   /**
    * 如果页面打开，并且authScript有值，说明是跨服务权限判断
    */
   if (authScript && id) {
     const isTrue = renderFormula(authScript.value, { authCode });
-    return isTrue ? (
-      <Button {...props} onClick={props.onClick}>
-        {props.children}
-      </Button>
-    ) : null;
+    return isTrue ? renderBtn(props) : null;
   }
   return <></>;
 }
+/**
+ * 生成按钮，当权限不符合时，不需要占位符
+ * @param param0 
+ * @returns 
+ */
+export const genAuthButton = ({ authCode, authScript, ...props }: any) => {
+  const { projectId, pageId, id } = useParams();
+  const buttons = storage.get('buttons') || [];
+  const pageMap = storage.get('pageMap');
+  const newAuthCode = projectId + '_' + pageMap[Number(pageId)]?.id + '_' + authCode;
+  /**
+   * 1. 如果没有配置权限，则直接显示按钮
+   * 2. 如果是页面打开，并且不是微服务环境，则直接显示按钮
+   * 3. 如果是项目打开，则判断是否配置了权限，根据权限进行查找，命中则显示按钮，否则不显示
+   */
+  if (!authCode || (id && !window.microApp) || (projectId && authCode && buttons.find((b: any) => b.code === newAuthCode))) {
+    return renderBtn(props);
+  }
+  /**
+   * 如果页面打开，并且authScript有值，说明是跨服务权限判断
+   */
+  if (authScript && id) {
+    const isTrue = renderFormula(authScript.value, { authCode });
+    return isTrue ? renderBtn(props) : null;
+  }
+  return null;
+};

--- a/packages/materials/Scene/MarsTable/MarsTable.tsx
+++ b/packages/materials/Scene/MarsTable/MarsTable.tsx
@@ -333,6 +333,7 @@ const MarsTable = ({ config, elements, onCheckedChange }: ComponentType<IConfig>
                 })
               // 过滤掉空按钮
               .filter((i: any) => i)
+              // 配置了折叠功能，且存在需要折叠的按钮
               if (moreActionIndex && btns.slice(moreActionIndex - 1).length) {
                 const content = <div style={{
                   display: 'flex',


### PR DESCRIPTION
---
name: pull request
about: 详细描述你的pr请求
title: 'fix: link、img、text组件click事件参数名对不上schema配置的eventName  feat: table组件支持折叠按钮'
labels: pr
assignees: ''
---

**目的**

请简要描述这个 Pull Request 的目的和解决的问题。如果这个 PR 相关的 Issue，请附上 Issue 链接。

**变更内容**

请详细描述此 PR 中的变更内容，列出所有修改的文件和功能点。

修改1：xiu f修复部份组件click事件参数名对不上schema配置的eventName

![image](https://github.com/user-attachments/assets/dc143fc3-aad2-4eb8-8b7f-2c08c546ab85)
![image](https://github.com/user-attachments/assets/62757360-5e11-497d-8961-490fe18f34a0)


修改2: 操作按钮新增折叠功能

![image](https://github.com/user-attachments/assets/93fc1763-88f2-4d7a-97e0-fa27a187ef73)
![image](https://github.com/user-attachments/assets/3d5b8cc3-8c39-4eec-9135-37eadb17a4ee)
用户端的table涉及到权限显示问题，这里会先过滤掉没权限的按钮，在做折叠处理

修改3：列弹窗标题增加key
![image](https://github.com/user-attachments/assets/66520abc-2670-428b-94b7-87ae2585aa8e)


