### PR TITLE
fix: styleConfig vsEditor hidden

### DIFF
--- a/packages/editor/src/components/StyleConfig/StyleConfig.tsx
+++ b/packages/editor/src/components/StyleConfig/StyleConfig.tsx
@@ -15,6 +15,15 @@ import Shadow from './Shadow';
 import VsEditor from '../VsEditor';
 import InputPx from './InputPx';
 import styles from './index.module.less';
+import { styled } from 'styled-components';
+// 修复contextmenu被裁剪显示不完整问题
+const StyleCodeEditor = styled.div `
+  .suggest-widget {
+    width: 100% !important;
+    left: 0 !important;
+    max-width: 500px !important;
+  }
+`;
 /**
  * 通用样式-配置组件
  */
@@ -83,9 +92,11 @@ const StyleConfig = () => {
   return (
     <Form className={styles.ui} {...formLayout} form={form} layout="horizontal" labelAlign="right" onValuesChange={run}>
       <TitleStyle>自定义样式</TitleStyle>
-      <Form.Item name="scopeCss" noStyle>
-        <VsEditor language="css" />
-      </Form.Item>
+      <StyleCodeEditor>
+        <Form.Item name="scopeCss" noStyle>
+          <VsEditor language="css" />
+        </Form.Item>
+      </StyleCodeEditor>
       <TitleStyle>基础</TitleStyle>
       <Form.Item name={['scopeStyle', 'width']} label={'宽度'}>
         <InputPx />


### PR DESCRIPTION
---
name: pull request
about: 修复编辑面板中，样式编辑器的contextmenu被遮挡的问题
title: 'fix: styleConfig vsEditor hidden'
labels: pr
assignees: ''
---

**目的**
解决显示不正常的问题
![img_v3_02ha_f9c9a907-668b-4ba4-91e3-00f2597f85bg](https://github.com/user-attachments/assets/8efd449d-7532-4bf7-a6af-1388f28cadcc)


**变更内容**

- [ ] 修改 1：添加样式覆盖
![t0NYzywyFO](https://github.com/user-attachments/assets/d91ac68e-f1a8-4d39-a6b7-40248238e0bf)

![img_v3_02ha_f9c9a907-668b-4ba4-91e3-00f2597f85bg](https://github.com/user-attachments/assets/897068f5-d950-433a-8fab-3ca2ad5d3324)
![t0NYzywyFO](https://github.com/user-attachments/assets/5fde789d-7fa7-4621-a192-b419cb99c442)
